### PR TITLE
fix: add eshe_instructor to allowedRoles [BB-7489]

### DIFF
--- a/src/data/thunkActions/roles.js
+++ b/src/data/thunkActions/roles.js
@@ -10,7 +10,7 @@ import { fetchGrades } from './grades';
 import { fetchTracks } from './tracks';
 import { fetchAssignmentTypes } from './assignmentTypes';
 
-export const allowedRoles = ['staff', 'instructor', 'support'];
+export const allowedRoles = ['staff', 'instructor', 'eshe_instructor', 'support'];
 
 export const fetchRoles = () => (
   (dispatch, getState) => {


### PR DESCRIPTION
eSHE Instructors can't view the gradebook without this.

Note: this is my personal fork. Once `open-craft/frontend-app-gradebook` is shared with OpenCraft Core group, I'll push `opencraft-release/nutmeg.2` there.